### PR TITLE
Fixed frame ID bug in sendAsync()

### DIFF
--- a/src/qtxb/xbee.cpp
+++ b/src/qtxb/xbee.cpp
@@ -320,13 +320,13 @@ void XBee::displayRemoteCommandResponse(RemoteATCommandResponse *digiMeshPacket)
  */
 void XBee::sendAsync(XBeePacket *packet)
 {
-    packet->assemblePacket();
     if(xbeeFound && m_serial->isOpen())
     {
         packet->setFrameId(m_frameIdCounter);
         if(m_frameIdCounter >= 255)
             m_frameIdCounter = 1;
         else m_frameIdCounter++;
+        packet->assemblePacket();
 
         qDebug() << Q_FUNC_INFO << "Transmit: " << QString("0x").append(packet->packet().toHex());
         m_serial->write(packet->packet());


### PR DESCRIPTION
As the packet is assembled before the frame id is set, the frame id send to the serial port is not correct. This can be fixed by assembling the packet after the frame id has been set.